### PR TITLE
Simplify word counting and add tests to template

### DIFF
--- a/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/cli.py
+++ b/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/cli.py
@@ -29,7 +29,7 @@ def cli(verbose):
         "Add Click commands and groups to the command line interface at "
         "src/{{ cookiecutter.package_name_underscored }}/cli.py"
     )
-    click.echo("See Click documenation at https://click.palletsprojects.com/en/stable/")
+    click.echo("See Click documentation at https://click.palletsprojects.com/en/stable/")
     click.echo(
         "Add your code as your see fit to the module at "
         "src/{{ cookiecutter.package_name_underscored }}/{{ cookiecutter.package_name_underscored }}.py"

--- a/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
+++ b/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
@@ -32,8 +32,9 @@ from typing import Dict
 def count_words(text: str) -> Dict[str, int]:
     """Count words in a given text string.
 
-    Count the number of words in a given text string, and return a dictionary
-    sorted by the number of words in descending order.
+    Count the number of words in a given text string, ignoring case and
+    punctuation, and return a dictionary sorted by the number of words in
+    descending order.
 
     Parameters
     ----------
@@ -46,15 +47,8 @@ def count_words(text: str) -> Dict[str, int]:
         The sorted dictionary mapping of word to word count
 
     """
-    words = text.split()
-    words_generator_object = (word.strip(string.punctuation) for word in words)
-    words_counter = Counter(words_generator_object)
-    words_dict = dict(words_counter)
-    words_dict_sorted = dict(
-            sorted(words_dict.items(), key=lambda item: item[1], reverse=True)
-    )
-
-    return words_dict_sorted
+    words = (word.strip(string.punctuation).lower() for word in text.split())
+    return dict(Counter(words).most_common())
 
 
 def main():

--- a/{{cookiecutter.package_name_hyphenated}}/tests/test_{{cookiecutter.package_name_underscored}}.py
+++ b/{{cookiecutter.package_name_hyphenated}}/tests/test_{{cookiecutter.package_name_underscored}}.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
 from {{ cookiecutter.package_name_underscored }}.cli import cli
+from {{ cookiecutter.package_name_underscored }}.{{ cookiecutter.package_name_underscored }} import count_words
 
 
 def test_version():
@@ -8,3 +9,9 @@ def test_version():
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert result.output.startswith("cli, version ")
+
+
+def test_count_words_basic():
+    """Ensure words are counted case-insensitively and punctuation is ignored."""
+    text = "Hello hello, world!"
+    assert count_words(text) == {"hello": 2, "world": 1}


### PR DESCRIPTION
## Summary
- refine word counting helper to ignore case/punctuation and use `Counter.most_common`
- add unit test for `count_words`
- fix documentation typo in CLI output

## Testing
- `pytest -q` *(fails: Invalid statement at pyproject.toml line 34)*

------
https://chatgpt.com/codex/tasks/task_e_689f8cdc5390832eb5c59aa93e8e4154