### PR TITLE
Handle punctuation-only tokens in word count

### DIFF
--- a/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
+++ b/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
@@ -47,8 +47,11 @@ def count_words(text: str) -> Dict[str, int]:
 
     """
     words = text.split()
-    words_generator_object = (word.strip(string.punctuation) for word in words)
-    words_counter = Counter(words_generator_object)
+    words_generator_object = (
+        word.strip(string.punctuation) for word in words
+    )
+    filtered_words = (word for word in words_generator_object if word)
+    words_counter = Counter(filtered_words)
     words_dict = dict(words_counter)
     words_dict_sorted = dict(
             sorted(words_dict.items(), key=lambda item: item[1], reverse=True)

--- a/{{cookiecutter.package_name_hyphenated}}/tests/test_{{cookiecutter.package_name_underscored}}.py
+++ b/{{cookiecutter.package_name_hyphenated}}/tests/test_{{cookiecutter.package_name_underscored}}.py
@@ -1,5 +1,8 @@
 from click.testing import CliRunner
 from {{ cookiecutter.package_name_underscored }}.cli import cli
+from {{ cookiecutter.package_name_underscored }}.{{ cookiecutter.package_name_underscored }} import (
+    count_words,
+)
 
 
 def test_version():
@@ -8,3 +11,10 @@ def test_version():
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert result.output.startswith("cli, version ")
+
+
+def test_count_words_punctuation_tokens():
+    text = "Hello!!! ???"
+    result = count_words(text)
+    assert "" not in result
+    assert result == {"Hello": 1}


### PR DESCRIPTION
## Summary
- filter out empty strings when counting words
- test punctuation-only tokens are ignored

## Testing
- `pytest -q -c /tmp/pytest.ini` *(fails: ModuleNotFoundError: No module named 'tests.test_{{cookiecutter')*

------
https://chatgpt.com/codex/tasks/task_e_689f8fc5d5b4832e9c8c2b22e92d8641