### PR TITLE
docs: update Click reference link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ References
 * `Simon Willison's Weblog - Things I've learned about building CLI tools in Python`_
 
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
-.. _Click: https://click.palletsprojects.com/en/7.x/
+.. _Click: https://click.palletsprojects.com/en/stable/
 .. _Python: https://www.python.org/
 .. _pip: https://pip.pypa.io/en/stable/
 .. _pytest: https://docs.pytest.org/en/latest/


### PR DESCRIPTION
## Summary
- fix README's Click reference URL to point to stable docs

## Testing
- `pytest` *(fails: ModuleNotFoundError for templated test module)*

------
https://chatgpt.com/codex/tasks/task_e_689f8fc22aa8832ebe5a18092085aabb