### PR TITLE
Ignore empty tokens when counting words

### DIFF
--- a/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
+++ b/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/{{cookiecutter.package_name_underscored}}.py
@@ -47,7 +47,11 @@ def count_words(text: str) -> Dict[str, int]:
 
     """
     words = text.split()
-    words_generator_object = (word.strip(string.punctuation) for word in words)
+    words_generator_object = (
+        stripped_word
+        for word in words
+        if (stripped_word := word.strip(string.punctuation))
+    )
     words_counter = Counter(words_generator_object)
     words_dict = dict(words_counter)
     words_dict_sorted = dict(


### PR DESCRIPTION
## Summary
- skip zero-length tokens when counting words to avoid counting punctuation-only strings

## Testing
- `pytest` *(fails: Invalid statement in pyproject.toml due to template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_689f8fbccbc8832eb13bb7e98fcdf67f