### PR TITLE
Fix CLI documentation typo

### DIFF
--- a/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/cli.py
+++ b/{{cookiecutter.package_name_hyphenated}}/src/{{cookiecutter.package_name_underscored}}/cli.py
@@ -29,7 +29,7 @@ def cli(verbose):
         "Add Click commands and groups to the command line interface at "
         "src/{{ cookiecutter.package_name_underscored }}/cli.py"
     )
-    click.echo("See Click documenation at https://click.palletsprojects.com/en/stable/")
+    click.echo("See Click documentation at https://click.palletsprojects.com/en/stable/")
     click.echo(
         "Add your code as your see fit to the module at "
         "src/{{ cookiecutter.package_name_underscored }}/{{ cookiecutter.package_name_underscored }}.py"


### PR DESCRIPTION
## Summary
- fix a typo in the CLI documentation message

## Testing
- `pytest -q` *(fails: Invalid statement in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_689f8fb6accc832eaa08a0ccd8b4cfdd